### PR TITLE
Update minimum versions, set maximum Python version, and fix macOS x86 installation

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,6 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+linter:
+  skip:
+    - lint_noarch_selectors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,8 @@
 {% set name = "pybispectra" %}
 {% set version = "1.2.4" %}
 {% set python_min = "3.10" %}
+{% set python_max = "3.14" %}
+{% set is_macos_intel = osx and x86}
 
 package:
   name: {{ name|lower }}
@@ -13,7 +15,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -21,14 +23,15 @@ requirements:
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
-    - joblib >=1.0
-    - matplotlib-base >=3.5
+    - python >={{ python_min }}, <{{ python_max }}
+    - joblib >=1.2
+    - matplotlib-base >=3.6
     - mne >=1.7
-    - numba >=0.55
-    - numpy >=1.21
-    - scikit-learn >=1.0
-    - scipy >=1.7
+    - numba >=0.56        # [not is_macos_intel]
+    - numba >=0.56, <0.63 # [is_macos_intel]
+    - numpy >=1.22
+    - scikit-learn >=1.1
+    - scipy >=1.8
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.2.4" %}
 {% set python_min = "3.10" %}
 {% set python_max = "3.14" %}
-{% set is_macos_intel = osx and x86}
+{% set is_macos_intel = osx and x86 %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python {{ python_min }},<{{ python_max }}
     - hatchling
     - pip
   run:
@@ -39,7 +39,7 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }}
+    - python {{ python_min }},<{{ python_max }}
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
   sha256: 54326457d3c339833dc7fb8c225d68923c20766be36a0af923527a7998206970
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
 
@@ -23,12 +22,12 @@ requirements:
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}, <{{ python_max }}
+    - python >={{ python_min }},<{{ python_max }}
     - joblib >=1.2
     - matplotlib-base >=3.6
     - mne >=1.7
-    - numba >=0.56        # [not is_macos_intel]
-    - numba >=0.56, <0.63 # [is_macos_intel]
+    - numba >=0.56  # [not is_macos_intel]
+    - numba >=0.56,<0.63  # [is_macos_intel]
     - numpy >=1.22
     - scikit-learn >=1.1
     - scipy >=1.8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,10 +17,6 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
 
-linter:
-  skip:
-    - lint_noarch_selectors
-
 requirements:
   host:
     - python {{ python_min }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,13 @@ source:
   sha256: 54326457d3c339833dc7fb8c225d68923c20766be36a0af923527a7998206970
 
 build:
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 1
+
+linter:
+  skip:
+    - lint_noarch_selectors
 
 requirements:
   host:


### PR DESCRIPTION
- Corrects errors in listed minimum-supported dependency versions
- Limit Python version to <3.14 (env can't resolve)
- Pin max numba version for macOS-intel systems
