### PR TITLE
FIX: Pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "pybispectra" %}
 {% set version = "1.3.1" %}
 {% set python_min = "3.10" %}
-{% set python_max = "3.14" %}
+{% set python_max_p1 = "3.15" %}
 
 package:
   name: {{ name|lower }}
@@ -14,15 +14,15 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
-    - python {{ python_min }},<={{ python_max }}
+    - python {{ python_min }},<{{ python_max_p1 }}
     - hatchling
     - pip
   run:
-    - python >={{ python_min }},<={{ python_max }}
+    - python >={{ python_min }},<{{ python_max_p1 }}
     - joblib >=1.2
     - matplotlib-base >=3.6
     - mne-base >=1.7
@@ -37,7 +37,7 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }},<={{ python_max }}
+    - python {{ python_min }},<{{ python_max_p1 }}
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "pybispectra" %}
 {% set version = "1.3.1" %}
 {% set python_min = "3.10" %}
-{% set python_max_p1 = "3.15" %}
 
 package:
   name: {{ name|lower }}
@@ -18,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }},<{{ python_max_p1 }}
+    - python {{ python_min }}
     - hatchling
     - pip
   run:
-    - python >={{ python_min }},<{{ python_max_p1 }}
+    - python >={{ python_min }}
     - joblib >=1.2
     - matplotlib-base >=3.6
     - mne-base >=1.7
@@ -37,7 +36,7 @@ test:
   commands:
     - pip check
   requires:
-    - python {{ python_min }},<{{ python_max_p1 }}
+    - python {{ python_min }}
     - pip
 
 about:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] ~~Reset the build number to `0` (if the version changed)~~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Current pinning to `<=3.14` is wrong:

<details>
<summary>Traceback</summary>

```
$ conda create -n test python=3.14.4 numba=0.65 --dry-run
Channels:
 - conda-forge
Platform: linux-64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - nothing provides _python_rc needed by python-3.14.0rc1-h4dad89b_2_cp314t

Could not solve for environment specs
The following packages are incompatible
├─ pybispectra =1.3.1 * is installable and it requires
│  └─ python >=3.10,<=3.14 * with the potential options
│     ├─ python [3.10.0|3.10.1|...|3.14.0], which can be installed;
│     ├─ python 3.14.0 would require
│     │  └─ python_abi =3.14 *_cp314, which requires
│     │     └─ python =3.14 *_cp314, which conflicts with any installable versions previously reported;
│     └─ python [3.14.0rc1|3.14.0rc2|3.14.0rc3] would require
│        └─ _python_rc =* *, which does not exist (perhaps a missing channel);
└─ python =3.14.4 * is not installable because there are no viable options
   ├─ python 3.14.4 conflicts with any installable versions previously reported;
   └─ python 3.14.4 would require
      └─ python_abi =3.14 *_cp314, which cannot be installed (as previously explained).
```

</details>

Personally this is the first time I have seen a python version max pin like this... unless breaking features are expected in 3.15 I don't think this is standard practice and I wouldn't do it.